### PR TITLE
Bump 6to5 version to 2.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/6to5/broccoli-6to5-transpiler",
   "dependencies": {
-    "6to5": "^2.7.3",
+    "6to5": "^2.9.3",
     "broccoli-filter": "^0.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates 6to5 dependency to `^2.9.3`.