### PR TITLE
bump 6to5 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/6to5/broccoli-6to5-transpiler",
   "dependencies": {
-    "6to5-core": "^2.11.0",
+    "6to5-core": "^2.12.4",
     "broccoli-filter": "^0.1.7",
     "clone": "^0.2.0"
   },


### PR DESCRIPTION
New version of 6to5 has ```for ... in``` loops switched to regular ```for``` loops for arrays.

This means if anything loads Ember before compilation (eg emberscript), the prototype extensions won't be iterated over

related: https://github.com/ember-cli/ember-cli/issues/2999

cc @stefanpenner @sebmck @rwjblue

Let me know if you want me to bump package version here too